### PR TITLE
add surface analyzer

### DIFF
--- a/src/main/java/org/osmsurround/ra/RelationStatisticsController.java
+++ b/src/main/java/org/osmsurround/ra/RelationStatisticsController.java
@@ -31,7 +31,7 @@ public class RelationStatisticsController {
 				AnalyzerContext analyzerContext = analyzerService.analyzeRelation(analyzeRelationModel.getRelationId(),
 						analyzeRelationModel.isNoCache());
 
-				return statisticsService.createRelationStatistics(analyzerContext.getRelation());
+				return statisticsService.createRelationStatisticsHighway(analyzerContext.getRelation());
 			}
 		}
 		catch (RelationGoneException e) {

--- a/src/main/java/org/osmsurround/ra/report/Report.java
+++ b/src/main/java/org/osmsurround/ra/report/Report.java
@@ -28,65 +28,91 @@ public class Report {
 	private RelationRating relationRating;
 	private RelationInfo relationInfo;
 	private List<ReportItem> reportItems;
-	private RelationStatistics relationStatistics;
+	private RelationStatistics highwayStatistics;
+	private RelationStatistics surfaceStatistics;
 	private String elevationProfileJson;
 
 	public Report() {
+
 	}
 
 	public Report(boolean gone) {
+
 		this.gone = gone;
 	}
 
 	public String getElevationProfileJson() {
+
 		return elevationProfileJson;
 	}
 
 	public void setElevationProfileJson(String elevationProfileJson) {
+
 		this.elevationProfileJson = elevationProfileJson;
 	}
 
 	public RelationRating getRelationRating() {
+
 		return relationRating;
 	}
 
 	public void setRelationRating(RelationRating relationRating) {
+
 		this.relationRating = relationRating;
 	}
 
 	public RelationInfo getRelationInfo() {
+
 		return relationInfo;
 	}
 
 	public void setRelationInfo(RelationInfo relationInfo) {
+
 		this.relationInfo = relationInfo;
 	}
 
 	public List<ReportItem> getReportItems() {
+
 		return reportItems;
 	}
 
 	public void setReportItems(List<ReportItem> reportItems) {
+
 		this.reportItems = reportItems;
 	}
 
-	public RelationStatistics getRelationStatistics() {
-		return relationStatistics;
+	public RelationStatistics getHighwayStatistics() {
+
+		return highwayStatistics;
 	}
 
-	public void setRelationStatistics(RelationStatistics relationStatistics) {
-		this.relationStatistics = relationStatistics;
+	public void setHighwayStatistics(RelationStatistics highwayStatistics) {
+
+		this.highwayStatistics = highwayStatistics;
+	}
+
+	public RelationStatistics getSurfaceStatistics() {
+
+		return surfaceStatistics;
+	}
+
+	public void setSurfaceStatistics(RelationStatistics surfaceStatistics) {
+
+		this.surfaceStatistics = surfaceStatistics;
 	}
 
 	public boolean isValidRelation() {
+
 		return validRelation;
 	}
 
 	public void setValidRelation(boolean validRelation) {
+
 		this.validRelation = validRelation;
 	}
 
 	public boolean isGone() {
+
 		return gone;
 	}
 }

--- a/src/main/java/org/osmsurround/ra/report/ReportService.java
+++ b/src/main/java/org/osmsurround/ra/report/ReportService.java
@@ -62,6 +62,7 @@ public class ReportService {
 	private ObjectMapper objectMapper = new ObjectMapper();
 
 	public Report generateReport(AnalyzerContext analyzerContext) {
+
 		Report report = new Report();
 		report.setValidRelation(true);
 		initReportItems(report, analyzerContext);
@@ -73,20 +74,22 @@ public class ReportService {
 	}
 
 	private void initElevationProfile(Report report, AnalyzerContext analyzerContext) {
+
 		try {
 			List<double[]> elevationProfile = elevationService.createElevationProfile(analyzerContext);
 			if (!elevationProfile.isEmpty()) {
 				String json = objectMapper.writeValueAsString(elevationProfile);
 				report.setElevationProfileJson(json);
 			}
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			log.info(e.getMessage());
 		}
 	}
 
 	private void initReportStatistics(Report report, AnalyzerContext analyzerContext) {
-		report.setRelationStatistics(statisticsService.createRelationStatistics(analyzerContext.getRelation()));
+
+		report.setHighwayStatistics(statisticsService.createRelationStatisticsHighway(analyzerContext.getRelation()));
+		report.setSurfaceStatistics(statisticsService.createRelationStatisticsSurface(analyzerContext.getRelation()));
 	}
 
 	private void initRelationInfo(Report report, AnalyzerContext analyzerContext) {
@@ -143,16 +146,19 @@ public class ReportService {
 	}
 
 	private void filterDistances(Set<NodeDistance> distances) {
+
 		int count = 0;
 		for (Iterator<NodeDistance> it = distances.iterator(); it.hasNext();) {
 			it.next();
 			count++;
-			if (count > MAX_DISTANCES)
+			if (count > MAX_DISTANCES) {
 				it.remove();
+			}
 		}
 	}
 
 	private Set<NodeDistance> getDistances(List<Graph> graphs, Node distantNode) {
+
 		Set<NodeDistance> distances = new TreeSet<NodeDistance>(NODE_DISTANCE_COMPARATOR);
 		for (Graph graph : graphs) {
 			Set<IntersectionNode> leaves = graph.getLeaves();
@@ -171,10 +177,10 @@ public class ReportService {
 	}
 
 	private void initRelationRating(Report report, AnalyzerContext analyzerContext) {
+
 		if (analyzerContext.getGraphs().isEmpty()) {
 			report.setRelationRating(new RelationRating(Rating.UNKNOWN, RELATION_NO_WAYS));
-		}
-		else {
+		} else {
 			Map<String, String> tags = analyzerContext.getRelation().getTags();
 			String relationType = tags.get("type");
 

--- a/src/main/java/org/osmsurround/ra/stats/Category.java
+++ b/src/main/java/org/osmsurround/ra/stats/Category.java
@@ -3,12 +3,12 @@ package org.osmsurround.ra.stats;
 import java.util.HashSet;
 import java.util.Set;
 
-public class HighwayCategory {
+public class Category {
 
 	private String name;
 	private Set<String> values = new HashSet<String>();
 
-	public HighwayCategory(String name, String... values) {
+	public Category(String name, String... values) {
 		this.name = name;
 		for (String value : values)
 			this.values.add(value);

--- a/src/main/java/org/osmsurround/ra/stats/Hierarchy.java
+++ b/src/main/java/org/osmsurround/ra/stats/Hierarchy.java
@@ -9,23 +9,23 @@ import java.util.Map.Entry;
 
 import org.osmtools.ra.data.Way;
 
-public class HighwayHierarchy {
+public class Hierarchy {
 
-	private Collection<HighwayHierarchy> subHierarchies = new ArrayList<HighwayHierarchy>();
+	private Collection<Hierarchy> subHierarchies = new ArrayList<Hierarchy>();
 
 	private String name;
 	private double length;
 	private int wayCount;
 	private Map<String, String> pattern = new HashMap<String, String>();
 
-	public HighwayHierarchy(String name, String... patterns) {
+	public Hierarchy(String name, String... patterns) {
 		this.name = name;
 		for (int x = 0; x < patterns.length; x += 2) {
 			pattern.put(patterns[x], patterns[x + 1]);
 		}
 	}
 
-	public void addSubHierarchy(HighwayHierarchy hierarchy) {
+	public void addSubHierarchy(Hierarchy hierarchy) {
 		subHierarchies.add(hierarchy);
 	}
 
@@ -39,7 +39,7 @@ public class HighwayHierarchy {
 		}
 
 		if (!added) {
-			for (HighwayHierarchy hierarchy : subHierarchies) {
+			for (Hierarchy hierarchy : subHierarchies) {
 				added = hierarchy.addWay(way, length);
 				if (added) {
 					this.length += length;
@@ -74,12 +74,12 @@ public class HighwayHierarchy {
 
 	private void appendDistributions(List<Distribution> distributions, int targetLayer, int currentLayer) {
 		if (targetLayer == currentLayer) {
-			for (HighwayHierarchy hierarchy : subHierarchies) {
+			for (Hierarchy hierarchy : subHierarchies) {
 				distributions.add(hierarchy.createDistribution());
 			}
 		}
 		else {
-			for (HighwayHierarchy hierarchy : subHierarchies) {
+			for (Hierarchy hierarchy : subHierarchies) {
 				hierarchy.appendDistributions(distributions, targetLayer, currentLayer + 1);
 			}
 		}

--- a/src/main/java/org/osmsurround/ra/stats/StatisticsService.java
+++ b/src/main/java/org/osmsurround/ra/stats/StatisticsService.java
@@ -1,5 +1,8 @@
 package org.osmsurround.ra.stats;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.osmtools.ra.data.Member;
 import org.osmtools.ra.data.Node;
 import org.osmtools.ra.data.Relation;
@@ -7,116 +10,197 @@ import org.osmtools.ra.data.Way;
 import org.osmtools.utils.LonLatMath;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Service
 public class StatisticsService {
 
-	private List<HighwayCategory> knownCategories = new ArrayList<HighwayCategory>();
+	private List<Category> knownHighwayCategories = new ArrayList<Category>();
+	private List<Category> knownSurfaceCategories = new ArrayList<Category>();
 
 	public StatisticsService() {
-		knownCategories.add(new HighwayCategory("motorway", "motorway", "motorway_link", "trunk", "trunk_link",
-				"primary", "primary_link"));
-		knownCategories
-				.add(new HighwayCategory("secondary", "secondary", "secondary_link", "tertiary", "tertiary_link"));
 
-		knownCategories.add(new HighwayCategory("calm", "pedestrian", "residential", "unclassified", "service",
+		knownHighwayCategories.add(new Category("motorway", "motorway", "motorway_link", "trunk", "trunk_link",
+				"primary", "primary_link"));
+		knownHighwayCategories
+				.add(new Category("secondary", "secondary", "secondary_link", "tertiary", "tertiary_link"));
+
+		knownHighwayCategories.add(new Category("calm", "pedestrian", "residential", "unclassified", "service",
 				"living_street"));
 
-		knownCategories.add(new HighwayCategory("track", "track", "cycleway"));
-		knownCategories.add(new HighwayCategory("path", "path", "footway", "steps", "bridleway"));
-		knownCategories.add(new HighwayCategory("unknown"));
+		knownHighwayCategories.add(new Category("track", "track", "cycleway"));
+		knownHighwayCategories.add(new Category("path", "path", "footway", "steps", "bridleway"));
+		knownHighwayCategories.add(new Category("unknown"));
+
+		knownSurfaceCategories.add(new Category("paved", "asphalt", "cobblestone", "sett", "concrete",
+				"concrete:lanes", "paving_stones", "metal", "wood"));
+		knownSurfaceCategories.add(new Category("unpaved", "compacted", "dirt", "earth", "fine_gravel", "grass",
+				"grass_paver", "gravel", "ground", "ice", "mud", "pebblestone", "salt", "sand", "snow", "woodchips"));
+		knownSurfaceCategories.add(new Category("unknown"));
 	}
 
-	private HighwayHierarchy createHierarchy() {
-		HighwayHierarchy hierarchy = new HighwayHierarchy("total");
+	private Hierarchy createHighwayHierarchy() {
 
-		HighwayHierarchy faststreets = new HighwayHierarchy("fast");
-		faststreets.addSubHierarchy(new HighwayHierarchy("motorway", "highway", "motorway"));
-		faststreets.addSubHierarchy(new HighwayHierarchy("motorway", "highway", "motorway_link"));
-		faststreets.addSubHierarchy(new HighwayHierarchy("trunk", "highway", "trunk"));
-		faststreets.addSubHierarchy(new HighwayHierarchy("trunk", "highway", "trunk_link"));
-		faststreets.addSubHierarchy(new HighwayHierarchy("primary", "highway", "primary"));
-		faststreets.addSubHierarchy(new HighwayHierarchy("primary", "highway", "primary_link"));
-		faststreets.addSubHierarchy(new HighwayHierarchy("secondary", "highway", "secondary"));
-		faststreets.addSubHierarchy(new HighwayHierarchy("secondary", "highway", "secondary_link"));
-		faststreets.addSubHierarchy(new HighwayHierarchy("tertiary", "highway", "tertiary"));
-		faststreets.addSubHierarchy(new HighwayHierarchy("tertiary", "highway", "tertiary_link"));
+		Hierarchy hierarchy = new Hierarchy("total");
+
+		Hierarchy faststreets = new Hierarchy("fast");
+		faststreets.addSubHierarchy(new Hierarchy("motorway", "highway", "motorway"));
+		faststreets.addSubHierarchy(new Hierarchy("motorway", "highway", "motorway_link"));
+		faststreets.addSubHierarchy(new Hierarchy("trunk", "highway", "trunk"));
+		faststreets.addSubHierarchy(new Hierarchy("trunk", "highway", "trunk_link"));
+		faststreets.addSubHierarchy(new Hierarchy("primary", "highway", "primary"));
+		faststreets.addSubHierarchy(new Hierarchy("primary", "highway", "primary_link"));
+		faststreets.addSubHierarchy(new Hierarchy("secondary", "highway", "secondary"));
+		faststreets.addSubHierarchy(new Hierarchy("secondary", "highway", "secondary_link"));
+		faststreets.addSubHierarchy(new Hierarchy("tertiary", "highway", "tertiary"));
+		faststreets.addSubHierarchy(new Hierarchy("tertiary", "highway", "tertiary_link"));
 
 		hierarchy.addSubHierarchy(faststreets);
 
-		HighwayHierarchy rural = new HighwayHierarchy("rural");
-		rural.addSubHierarchy(new HighwayHierarchy("residential", "highway", "residential"));
-		rural.addSubHierarchy(new HighwayHierarchy("living_street", "highway", "living_street"));
-		rural.addSubHierarchy(new HighwayHierarchy("service", "highway", "service"));
-		rural.addSubHierarchy(new HighwayHierarchy("unclassified", "highway", "unclassified"));
-		rural.addSubHierarchy(new HighwayHierarchy("bus_guideway", "highway", "bus_guideway"));
+		Hierarchy rural = new Hierarchy("rural");
+		rural.addSubHierarchy(new Hierarchy("residential", "highway", "residential"));
+		rural.addSubHierarchy(new Hierarchy("living_street", "highway", "living_street"));
+		rural.addSubHierarchy(new Hierarchy("service", "highway", "service"));
+		rural.addSubHierarchy(new Hierarchy("unclassified", "highway", "unclassified"));
+		rural.addSubHierarchy(new Hierarchy("bus_guideway", "highway", "bus_guideway"));
 
 		hierarchy.addSubHierarchy(rural);
 
-		HighwayHierarchy tracks = new HighwayHierarchy("tracks");
-		tracks.addSubHierarchy(new HighwayHierarchy("track-g1", "highway", "track", "tracktype", "grade1"));
-		tracks.addSubHierarchy(new HighwayHierarchy("track-g2", "highway", "track", "tracktype", "grade2"));
-		tracks.addSubHierarchy(new HighwayHierarchy("track-g3", "highway", "track", "tracktype", "grade3"));
-		tracks.addSubHierarchy(new HighwayHierarchy("track-g4", "highway", "track", "tracktype", "grade4"));
-		tracks.addSubHierarchy(new HighwayHierarchy("track-g5", "highway", "track", "tracktype", "grade5"));
-		tracks.addSubHierarchy(new HighwayHierarchy("track-unknown", "highway", "track"));
+		Hierarchy tracks = new Hierarchy("tracks");
+		tracks.addSubHierarchy(new Hierarchy("track-g1", "highway", "track", "tracktype", "grade1"));
+		tracks.addSubHierarchy(new Hierarchy("track-g2", "highway", "track", "tracktype", "grade2"));
+		tracks.addSubHierarchy(new Hierarchy("track-g3", "highway", "track", "tracktype", "grade3"));
+		tracks.addSubHierarchy(new Hierarchy("track-g4", "highway", "track", "tracktype", "grade4"));
+		tracks.addSubHierarchy(new Hierarchy("track-g5", "highway", "track", "tracktype", "grade5"));
+		tracks.addSubHierarchy(new Hierarchy("track-unknown", "highway", "track"));
 
 		hierarchy.addSubHierarchy(tracks);
 
-		HighwayHierarchy humans = new HighwayHierarchy("humans");
-		humans.addSubHierarchy(new HighwayHierarchy("pedestrian", "highway", "pedestrian"));
-		humans.addSubHierarchy(new HighwayHierarchy("path", "highway", "path"));
-		humans.addSubHierarchy(new HighwayHierarchy("footway", "highway", "footway"));
-		humans.addSubHierarchy(new HighwayHierarchy("steps", "highway", "steps"));
-		humans.addSubHierarchy(new HighwayHierarchy("bridleway", "highway", "bridleway"));
-		humans.addSubHierarchy(new HighwayHierarchy("cycleway", "highway", "cycleway"));
+		Hierarchy humans = new Hierarchy("humans");
+		humans.addSubHierarchy(new Hierarchy("pedestrian", "highway", "pedestrian"));
+		humans.addSubHierarchy(new Hierarchy("path", "highway", "path"));
+		humans.addSubHierarchy(new Hierarchy("footway", "highway", "footway"));
+		humans.addSubHierarchy(new Hierarchy("steps", "highway", "steps"));
+		humans.addSubHierarchy(new Hierarchy("bridleway", "highway", "bridleway"));
+		humans.addSubHierarchy(new Hierarchy("cycleway", "highway", "cycleway"));
 
 		hierarchy.addSubHierarchy(humans);
 
-		HighwayHierarchy unknown = new HighwayHierarchy("unknown");
-		unknown.addSubHierarchy(new HighwayHierarchy("unknown", "highway", "*"));
+		Hierarchy unknown = new Hierarchy("unknown");
+		unknown.addSubHierarchy(new Hierarchy("unknown", "highway", "*"));
 
 		hierarchy.addSubHierarchy(unknown);
 
 		return hierarchy;
 	}
 
-	public RelationStatistics createRelationStatistics(Relation relation) {
+	private Hierarchy createSurfaceHierarchy() {
 
-		HighwayHierarchy hierarchy = createHierarchy();
+		Hierarchy hierarchy = new Hierarchy("total");
+
+		Hierarchy paved = new Hierarchy("paved");
+		paved.addSubHierarchy(new Hierarchy("paved", "surface", "paved"));
+		paved.addSubHierarchy(new Hierarchy("asphalt", "surface", "asphalt"));
+		paved.addSubHierarchy(new Hierarchy("cobblestone", "surface", "cobblestone"));
+		paved.addSubHierarchy(new Hierarchy("sett", "surface", "sett"));
+		paved.addSubHierarchy(new Hierarchy("concrete", "surface", "concrete"));
+		paved.addSubHierarchy(new Hierarchy("concrete", "surface", "concrete:lanes"));
+		paved.addSubHierarchy(new Hierarchy("paving_stones", "surface", "paving_stones"));
+		paved.addSubHierarchy(new Hierarchy("paving_stones", "surface", "paving_stones:30"));
+		paved.addSubHierarchy(new Hierarchy("paving_stones", "surface", "paving_stones:20"));
+		paved.addSubHierarchy(new Hierarchy("metal", "surface", "metal"));
+		paved.addSubHierarchy(new Hierarchy("wood", "surface", "wood"));
+		hierarchy.addSubHierarchy(paved);
+
+		Hierarchy unpaved = new Hierarchy("unpaved");
+		unpaved.addSubHierarchy(new Hierarchy("unpaved", "surface", "unpaved"));
+		unpaved.addSubHierarchy(new Hierarchy("compacted", "surface", "compacted"));
+		unpaved.addSubHierarchy(new Hierarchy("dirt", "surface", "dirt"));
+		unpaved.addSubHierarchy(new Hierarchy("earth", "surface", "earth"));
+		unpaved.addSubHierarchy(new Hierarchy("gravel", "surface", "fine_gravel"));
+		unpaved.addSubHierarchy(new Hierarchy("gravel", "surface", "gravel"));
+		unpaved.addSubHierarchy(new Hierarchy("grass", "surface", "grass"));
+		unpaved.addSubHierarchy(new Hierarchy("grass_paver", "surface", "grass_paver"));
+		unpaved.addSubHierarchy(new Hierarchy("ground", "surface", "ground"));
+		unpaved.addSubHierarchy(new Hierarchy("ice", "surface", "ice"));
+		unpaved.addSubHierarchy(new Hierarchy("mud", "surface", "mud"));
+		unpaved.addSubHierarchy(new Hierarchy("pebblestone", "surface", "pebblestone"));
+		unpaved.addSubHierarchy(new Hierarchy("salt", "surface", "salt"));
+		unpaved.addSubHierarchy(new Hierarchy("sand", "surface", "sand"));
+		unpaved.addSubHierarchy(new Hierarchy("snow", "surface", "snow"));
+		unpaved.addSubHierarchy(new Hierarchy("woodchips", "surface", "woodchips"));
+		hierarchy.addSubHierarchy(unpaved);
+
+		Hierarchy untagged = new Hierarchy("untagged");
+		untagged.addSubHierarchy(new Hierarchy("untagged", "surface", "untagged"));
+		hierarchy.addSubHierarchy(untagged);
+
+		Hierarchy unknown = new Hierarchy("unknown");
+		unknown.addSubHierarchy(new Hierarchy("unknown", "surface", "*"));
+		hierarchy.addSubHierarchy(unknown);
+
+		return hierarchy;
+	}
+
+	public RelationStatistics createRelationStatisticsHighway(Relation relation) {
+
+		Hierarchy highwayHierarchy = createHighwayHierarchy();
 
 		for (Member member : relation.getMembers()) {
 			Way way = member.getWay();
 			List<Node> nodes = way.getNodes();
 			double length = LonLatMath.distance(nodes.get(0), nodes.get(nodes.size() - 1));
-			hierarchy.addWay(way, length);
+			highwayHierarchy.addWay(way, length);
 		}
 
 		List<Distribution> distributions = new ArrayList<Distribution>();
-		hierarchy.appendDistributions(distributions, 1);
+		highwayHierarchy.appendDistributions(distributions, 1);
+
 		RelationStatistics relationStatistics = new RelationStatistics(distributions);
 		relationStatistics.finish();
 
-		//		for (HighwayCategory category : knownCategories)
-		//			distributions.add(new Distribution(category.getName()));
+		// for (HighwayCategory category : knownCategories)
+		// distributions.add(new Distribution(category.getName()));
 		//
-		//		RelationStatistics relationStatistics = new RelationStatistics(distributions);
+		// RelationStatistics relationStatistics = new
+		// RelationStatistics(distributions);
 		//
-		//		for (Member member : relation.getMembers()) {
-		//			identifyWay(member.getWay(), relationStatistics);
-		//		}
+		// for (Member member : relation.getMembers()) {
+		// identifyWay(member.getWay(), relationStatistics);
+		// }
 		//
-		//		relationStatistics.finish();
+		// relationStatistics.finish();
+
+		return relationStatistics;
+
+	}
+
+	public RelationStatistics createRelationStatisticsSurface(Relation relation) {
+
+		Hierarchy surfaceHierarchy = createSurfaceHierarchy();
+
+		for (Member member : relation.getMembers()) {
+			Way way = member.getWay();
+			List<Node> nodes = way.getNodes();
+			double length = LonLatMath.distance(nodes.get(0), nodes.get(nodes.size() - 1));
+			if (!way.getTags().containsKey("surface")) {
+				way.getTags().put("surface", "untagged");
+			}
+			surfaceHierarchy.addWay(way, length);
+		}
+
+		List<Distribution> distributions = new ArrayList<Distribution>();
+		surfaceHierarchy.appendDistributions(distributions, 1);
+
+		RelationStatistics relationStatistics = new RelationStatistics(distributions);
+		relationStatistics.finish();
 
 		return relationStatistics;
 
 	}
 
 	private void identifyWay(Way way, RelationStatistics relationStatistics) {
+
 		String highway = way.getTags().get("highway");
-		HighwayCategory category = identifyCategory(highway);
+		Category category = identifyCategory(highway);
 
 		List<Node> nodes = way.getNodes();
 		double length = LonLatMath.distance(nodes.get(0), nodes.get(nodes.size() - 1));
@@ -124,8 +208,9 @@ public class StatisticsService {
 		relationStatistics.addWay(category.getName(), length);
 	}
 
-	private HighwayCategory identifyCategory(String highway) {
-		for (HighwayCategory highwayCategory : knownCategories) {
+	private Category identifyCategory(String highway) {
+
+		for (Category highwayCategory : knownHighwayCategories) {
 			if (highwayCategory.isCategory(highway)) {
 				return highwayCategory;
 			}

--- a/src/main/webapp/WEB-INF/messages/content.properties
+++ b/src/main/webapp/WEB-INF/messages/content.properties
@@ -4,7 +4,8 @@ title.analyze=Relation analysis
 title.search=Relation search
 title.rating=Rating
 title.report=Report
-title.statistics=Way distribution
+title.statistics.highway=Way distribution
+title.statistics.surface=Surface distribution
 title.elevation.profile=Elevation profile
 
 label.name=Relation Name
@@ -65,8 +66,10 @@ link.title.potlatch=Link to Potlatch
 form.errors=Please fill in at least one search field.
 editor.links=Editor links:
 
-info.statistics=Shows the distribution of way types in this relations. Hover over a color for more details.
-legend.statistics=red = major roads, blue = rural roads, brown = tracks, green = footways and cycleways, gray = unknown
+info.statistics.highway=Shows the distribution of way types in this relations. Hover over a color for more details.
+legend.statistics.highway=red = major roads, blue = rural roads, brown = tracks, green = footways and cycleways, gray = unknown
+info.statistics.surface=Shows the distribution of way surfaces in this relations. Hover over a color for more details.
+legend.statistics.surface=solid = paved, dashed = unpaved, blue = no surface tag on way
 
 modified.less.minute=less than a minute ago
 modified.minute=one minute ago

--- a/src/main/webapp/WEB-INF/messages/content_de.properties
+++ b/src/main/webapp/WEB-INF/messages/content_de.properties
@@ -5,6 +5,7 @@ title.search=Relation Suche
 title.rating=Bewertung
 title.report=Report
 title.statistics=Way-Verteilung
+title.statistics.surface=Oberflächen-Verteilung
 title.elevation.profile=Höhenprofil
 
 label.name=Relation Name
@@ -63,8 +64,10 @@ link.title.potlatch=Link zu Potlatch
 
 form.errors=Bitte mindestens ein Feld ausfüllen.
 editor.links=Links zu Editoren:
-info.statistics=Zeigt die Verteilung der Ways innerhalb der Relation. Bewege die Maus über eine Farbe für mehr Details.
-legend.statistics=rot = Hauptstrassen, blau = städtische Strassen, braun = tracks, grün = Fuß- und Radwege, grau = unbekannt
+info.statistics.highway=Zeigt die Verteilung der Ways innerhalb der Relation. Bewege die Maus über eine Farbe für mehr Details.
+legend.statistics.highway=rot = Hauptstrassen, blau = städtische Strassen, braun = tracks, grün = Fuß- und Radwege, grau = unbekannt
+info.statistics.surface=Zeigt die Verteilung der Oberflächen innerhalb der Relation. Bewege die Maus über eine Farbe für mehr Details.
+legend.statistics.surface=vollfarbig = paved, schraffiert = unpaved, blau = surface nicht getaggt
 
 modified.less.minute=vor weniger als einer Minute
 modified.minute=vor einer Minute

--- a/src/main/webapp/WEB-INF/views/analyzeResult.jsp
+++ b/src/main/webapp/WEB-INF/views/analyzeResult.jsp
@@ -82,20 +82,33 @@
 </div>
 </c:if>
 
-<c:if test="${report.relationStatistics.length > 0}">
+<c:if test="${report.highwayStatistics.length > 0}">
 <div class="well">
-<h3><spring:message code="title.statistics"/></h3>
+<h3><spring:message code="title.statistics.highway"/></h3>
 <div style="overflow:hidden">
-<c:forEach items="${report.relationStatistics.distributions}" var="item">
+<c:forEach items="${report.highwayStatistics.distributions}" var="item">
 <div style="float:left;width:${item.percent*100}%;height:24px" class="dist-${item.name}" title="${item.name}, <fmt:formatNumber pattern="#,##0.0">${item.percent*100}</fmt:formatNumber>%, length: <fmt:formatNumber pattern="#,##0.00">${item.length}</fmt:formatNumber> KM, ways: ${item.wayCount}"></div>
 </c:forEach>
 </div>
-<div style="clear:both;margin-top:10px"><spring:message code="info.statistics"/><br/>
-<spring:message code="legend.statistics"/></div>
+<div style="clear:both;margin-top:10px"><spring:message code="info.statistics.highway"/><br/>
+<spring:message code="legend.statistics.highway"/></div>
 <a class="btn" href="relationStatistics?relationId=${report.relationInfo.relationId}" ><spring:message code="button.download.statistics" /></a>
 </div>
 </c:if>
 
+<c:if test="${report.surfaceStatistics.length > 0}">
+<div class="well">
+<h3><spring:message code="title.statistics.surface"/></h3>
+<div style="overflow:hidden">
+<c:forEach items="${report.surfaceStatistics.distributions}" var="item">
+<div style="float:left;width:${item.percent*100}%;height:24px" class="dist-${item.name}" title="${item.name}, <fmt:formatNumber pattern="#,##0.0">${item.percent*100}</fmt:formatNumber>%, length: <fmt:formatNumber pattern="#,##0.00">${item.length}</fmt:formatNumber> KM, ways: ${item.wayCount}"></div>
+</c:forEach>
+</div>
+<div style="clear:both;margin-top:10px"><spring:message code="info.statistics.surface"/><br/>
+<spring:message code="legend.statistics.surface"/></div>
+<!--<a class="btn" href="relationStatistics?relationId=${report.relationInfo.relationId}" ><spring:message code="button.download.statistics" /></a>-->
+</div>
+</c:if>
 
 <div class="well">
 <h3><spring:message code="title.report"/></h3>

--- a/src/main/webapp/resources/ra.css
+++ b/src/main/webapp/resources/ra.css
@@ -81,6 +81,63 @@
 	background-color: #00CD66;
 }
 
+.dist-paved {
+	background-color: red;
+}
+.dist-asphalt {
+	background-color: black;
+}
+.dist-paving_stones {
+	background-color: gray;
+}
+.dist-concrete {
+	background-color: lightgray;
+}
+.dist-wood {
+	background-color: yellow;
+}
+
+.dist-unpaved {
+	background-color: red;
+	background-image: -webkit-linear-gradient(45deg,rgba(255,255,255,.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,.15) 50%,rgba(255,255,255,.15) 75%,transparent 75%,transparent);
+}
+.dist-compacted {
+	background-color: darkgray;
+	background-image: -webkit-linear-gradient(45deg,rgba(255,255,255,.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,.15) 50%,rgba(255,255,255,.15) 75%,transparent 75%,transparent);
+}
+.dist-gravel {
+	background-color: gray;
+	background-image: -webkit-linear-gradient(45deg,rgba(255,255,255,.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,.15) 50%,rgba(255,255,255,.15) 75%,transparent 75%,transparent);
+	}
+.dist-grass_paver {
+	background-color: lightgray;
+	background-image: -webkit-linear-gradient(45deg,rgba(255,255,255,.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,.15) 50%,rgba(255,255,255,.15) 75%,transparent 75%,transparent);
+	}
+.dist-grass {
+	background-color: green;
+	background-image: -webkit-linear-gradient(45deg,rgba(255,255,255,.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,.15) 50%,rgba(255,255,255,.15) 75%,transparent 75%,transparent);
+	}
+.dist-ground,
+.dist-earth {
+	background-color: brown;
+	background-image: -webkit-linear-gradient(45deg,rgba(255,255,255,.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,.15) 50%,rgba(255,255,255,.15) 75%,transparent 75%,transparent);
+	}
+.dist-dirt,
+.dist-mud {
+	background-color: saddlebrown;
+	background-image: -webkit-linear-gradient(45deg,rgba(255,255,255,.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,.15) 50%,rgba(255,255,255,.15) 75%,transparent 75%,transparent);
+	}
+}
+.dist-sand,
+.dist-salt {
+	background-color: wheat;
+	background-image: -webkit-linear-gradient(45deg,rgba(255,255,255,.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,.15) 50%,rgba(255,255,255,.15) 75%,transparent 75%,transparent);
+	}
+
+.dist-untagged {
+	background-color: blue;
+}
+
 .dist-unknown {
-	background-color: #EEE;
+	background-color: #DDD;
 }

--- a/src/test/java/org/osmsurround/ra/stats/StatisticsServiceTest.java
+++ b/src/test/java/org/osmsurround/ra/stats/StatisticsServiceTest.java
@@ -16,7 +16,7 @@ public class StatisticsServiceTest extends TestBase {
 
 		AnalyzerContext analyzerContext = helperService.createGraphContext(TestUtils.RELATION_12320_NECKARTAL_WEG);
 
-		RelationStatistics relationStatistics = statisticsService.createRelationStatistics(analyzerContext
+		RelationStatistics relationStatistics = statisticsService.createRelationStatisticsHighway(analyzerContext
 				.getRelation());
 
 		for (Distribution distribution : relationStatistics.getDistributions()) {


### PR DESCRIPTION
Hi Adrian,
i've added the surface analyzer.

What i've done:
* renamed HighwayCategory.java and HighwayHierarchy.java to more common name Category and Hierarchy
* StatisticsService get new methods about surface
* add following lines to StatisticsService.createRelationStatisticsSurface, because some ways haven't a surface tag. I think you should think about it in highway-statistics, too! What if a way hasn't got a highway-tag?
```	
    if (!way.getTags().containsKey("surface")) {
        way.getTags().put("surface", "untagged");
    }
```
* finally add a new statistics block in analyzeResult.jsp

Perhaps it makes sense to make StatisticsService abstract and extend to HighwayStatistics and SurfaceStatistics

Screenshot:
![image](https://cloud.githubusercontent.com/assets/8296940/9025944/3b88ac68-391b-11e5-82d6-2eedfd249b0f.png)

Regards,
Harald Hartmann