### PR TITLE
Update content-generic.properties: Rename potlatch-link to iD editor

### DIFF
--- a/src/main/webapp/WEB-INF/messages/content-generic.properties
+++ b/src/main/webapp/WEB-INF/messages/content-generic.properties
@@ -1,2 +1,2 @@
-link.label.potlatch=Potlatch
+link.label.potlatch=iD-Editor
 link.label.josmrc=JOSM


### PR DESCRIPTION
The goal of this is to have the correct label in the map overlays, eg at http://ra.osmsurround.org/analyzeMap?relationId=1960136

This continues the hacky workaround which re-uses the potlatch link for the iD editor.
- see https://github.com/grundid/relation-analyzer/blob/master/src/main/java/org/osmsurround/tags/builder/PotlatchLinkBuilder.java#L12
- see https://github.com/grundid/relation-analyzer/blob/master/src/main/webapp/WEB-INF/messages/content_de.properties#L63
